### PR TITLE
Fix RTC functionalities

### DIFF
--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -252,7 +252,7 @@ impl Rtc<RtcClkHseDiv128> {
 
     /// Tries to obtain currently running RTC to prevent reset in case it was running from VBAT.
     /// If the RTC is not running, or is not HSE, it will be reinitialized.
-    pub fn restore_or_new_hse(rcc: &mut Rcc, regs: RTC, pwr:&mut PWR, hse: Hertz) -> RestoredOrNewRtc<RtcClkHseDiv128> {
+    pub fn restore_or_new_hse(regs: RTC, rcc: &mut Rcc, pwr:&mut PWR, hse: Hertz) -> RestoredOrNewRtc<RtcClkHseDiv128> {
         if !Self::is_enabled(&mut rcc.regs) {
             RestoredOrNewRtc::New(Rtc::new_hse(regs, hse, rcc, pwr))
         } else {

--- a/src/rtc.rs
+++ b/src/rtc.rs
@@ -1,7 +1,7 @@
 /*!
   Real time clock
 */
-use crate::pac::{RCC, RTC, PWR};
+use crate::pac::{PWR, RCC, RTC};
 
 use crate::time::{Hertz, Hz};
 
@@ -224,7 +224,6 @@ impl Rtc<RtcClkLsi> {
         let prescaler = LSI_HERTZ.raw() / frequency.raw() - 1;
         self.set_prescaler(prescaler);
     }
-
 }
 
 impl Rtc<RtcClkHseDiv128> {
@@ -310,7 +309,7 @@ impl Rtc<RtcClkHseDiv128> {
 }
 
 impl<CS> Rtc<CS> {
-    fn enable_apb_and_dbp () {
+    fn enable_apb_and_dbp() {
         let rcc = unsafe { &*RCC::ptr() };
         rcc.apbenr1.modify(|_, w| w.pwren().set_bit());
         rcc.apbenr1.modify(|_, w| w.rtcapben().set_bit());
@@ -434,7 +433,7 @@ impl<CS> Rtc<CS> {
 
         // Take the device out of config mode
         self.regs.crl.modify(|_, w| w.cnf().clear_bit());
-        
+
         // Wait for the write to be done
         while !self.regs.crl.read().rtoff().bit() {}
     }


### PR DESCRIPTION
## Observations
I have tried current RTC implements on PY32F030，it doesn't work.

The mainly reason are:
1) It doesn't enable RTC's APB interface.
2) It doesn't set PWR_CR1's DBP bit to 1 to unlock RCC_BDCR for writing.

Also, some other bugs are found:
1) When MCU reset (restoring), it didn't re-enalbe RTC's APB interface and re-set PWR_CR1's DBP bit to 1.

2) select_frequency() function should not be shared between all 3 RTC's. Because the RTC CLK base frequency is very different for RtcClkHseDiv128

## Mainly Changes
1) Enable RTC's APB interface & unlock DBP bit when "new" or "restoring"
2) Fix the "select_frequency()" function for RtcClkHseDiv128
3) Do some refactorings to extract some common code.

## Testing
For each of RTC Clock Source: HSE, LSE, LSI.
1. Disconnect POWER, re-connect POWER, and check the RTC can be initialize, and the RTC counting is correct.

2. Keep the POWER, and reset the MCU, then check the RTC counter are not reset and can continue counting.

Would you have a look at this PR when you have time? @gpgreen 